### PR TITLE
Fix swapped PT pins

### DIFF
--- a/boards/lpl/gnc_legacy/throttle_legacy.dts
+++ b/boards/lpl/gnc_legacy/throttle_legacy.dts
@@ -50,7 +50,7 @@ To the find devicetree ADC channel for a teensy ADC pin:
 
         // HACK: For whatever reason the io-channels may be getting auto-sorted? Thus, we order our pt labels
         // corresponding to the sorted ascending order of ADC1 channels. The following corresonds to pins A0, A1, A3,
-        // and A2.
+        // and A2. We really ought investigate further.
         pt-names = "pt201", "pt202", "pt204", "pt203";
         io-channels = <&adc1 7>, <&adc1 8>, <&adc1 11>, <&adc1 12>;
     };


### PR DESCRIPTION
pinctrl pinmux ordering seems to be mapped to the ordering of channels in the adc block for the purposes of mapping channels to outputs it seems.