### PR TITLE
Fixed PT pin assignments

### DIFF
--- a/boards/lpl/gnc_legacy/throttle_legacy.dts
+++ b/boards/lpl/gnc_legacy/throttle_legacy.dts
@@ -53,7 +53,7 @@ To the find devicetree ADC channel for a teensy ADC pin:
         // HACK: For whatever reason the io-channels may be getting auto-sorted? Thus, we order our pt labels
         // corresponding to the sorted ascending order of ADC1 channels. The following corresonds to pins A0, A1, A3,
         // and A2. We really ought investigate further.
-        pt-names = "pt203", "pt204", "ptf401", "pt102";
+        pt-names = "pt102", "pt203", "pt204", "ptf401";
         io-channels = <&adc1 7>, <&adc1 8>, <&adc1 11>, <&adc1 12>;
     };
 


### PR DESCRIPTION
Fixed PT pin assignments to reflect the broken PT socket on throttle legacy PCB