### PR TITLE
Fix data loss error from incorrect connection close handling

### DIFF
--- a/gnc/prj.conf
+++ b/gnc/prj.conf
@@ -55,6 +55,11 @@ CONFIG_NET_LOG=y
 CONFIG_ADC=y
 CONFIG_ADC_LOG_LEVEL_WRN=y
 
+# Uncomment to configure a periodic console message of thread CPU/stack usage.
+# CONFIG_THREAD_ANALYZER=y
+# CONFIG_THREAD_ANALYZER_AUTO=y
+# CONFIG_THREAD_ANALYZER_AUTO_INTERVAL=5
+# CONFIG_THREAD_NAME=y
 
 
 


### PR DESCRIPTION
Fixes data loss during sequence. This was caused by closing connections, which was not properly handled. The client thread would spin forever, eating all CPU time from the data sender thread, which would be unable to send messages.

TODO: Data sender should temporarily get a bump in priority?