### PR TITLE
Force x86 for dev container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "arty",
   "runArgs": [
-    "--network=host"
+    "--network=host",
+    "--platform=linux/amd64"
   ],
   "workspaceFolder": "/workspaces/arty",
   "privileged": true,


### PR DESCRIPTION
Otherwise on MacOS dev container creation will fail as it tries to pull an arm64 image.