### PR TITLE
Attempt to force x86 in image pull

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -4,6 +4,9 @@
     "--network=host",
     "--platform=linux/amd64"
   ],
+  "build": {
+    "options": ["--platform=linux/amd64"]
+  },
   "workspaceFolder": "/workspaces/arty",
   "privileged": true,
   "remoteUser": "lpl",


### PR DESCRIPTION
Previous method of setting platform in run args was insufficient.